### PR TITLE
Proposal to change directors from a two-year to a three-year term

### DIFF
--- a/policies/board-of-directors-election-policy.md
+++ b/policies/board-of-directors-election-policy.md
@@ -16,7 +16,7 @@ Each individual member of the Foundation current at the time of the election is 
 
 At-Large Directors are elected to a three-year term.
 
-For the 2020-2021 Board term only, once the incoming Board of Directors is seated, staggered term durations will be established among the six At-Large Director seats to help enhance the continuity of the organization's governance. Specifically, three At-Large Director seats will be chosen randomly to serve a one-time, one-year term. The remaining three At-Large Director seats will have the standard two-year term. For all subsequent elections, the Foundation's members will elect only three At-Large Director seats each year.
+For the 2020-2021 Board term only, once the incoming Board of Directors is seated, staggered term durations will be established among the six At-Large Director seats to help enhance the continuity of the organization's governance. Specifically, three At-Large Director seats will be chosen randomly to serve a one-time, one-year term. The remaining three At-Large Director seats will have the standard three-year term. For all subsequent elections, the Foundation's members will elect only three At-Large Director seats each year.
 
 ## Vacancies
 

--- a/policies/board-of-directors-election-policy.md
+++ b/policies/board-of-directors-election-policy.md
@@ -14,7 +14,7 @@ Each individual member of the Foundation current at the time of the election is 
 
 ## Director Terms + Term Staggering
 
-At-Large Directors are elected to a two-year term.
+At-Large Directors are elected to a three-year term.
 
 For the 2020-2021 Board term only, once the incoming Board of Directors is seated, staggered term durations will be established among the six At-Large Director seats to help enhance the continuity of the organization's governance. Specifically, three At-Large Director seats will be chosen randomly to serve a one-time, one-year term. The remaining three At-Large Director seats will have the standard two-year term. For all subsequent elections, the Foundation's members will elect only three At-Large Director seats each year.
 


### PR DESCRIPTION
We are proposing to extend the term of directors from two years to three years.  We have found that rapid turnover within the foundation has made it difficult to address longer-term issues and have a reasonable promotion of directors to leadership roles within the foundation.  It's important that leadership roles are able to grow first observing in the foundation before taking on a leadership role and in turn advancing to a higher role.  Having a three-year term affords the possibility of doing this within a single term.

As part of changing to the three-year term, there will not be an election cycle in 2025 with the next cycle being in 2026.

In compliance with Section 3.9(f) of the [Board of Directors Election Policy and Procedures](https://dotnetfoundation.org/about/policies/board-of-directors-election-policy), we are posting this proposed change and requesting Member comments on this Pull Request through May 31st, 2025 at 00:00 UTC.